### PR TITLE
fix for nodejs require bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "engines": {
     "node": ">=0.10.0"
   },
-  "main": "./lib/apostle.js",
+  "main": "./lib/index.js",
   "dependencies": {
 	  "superagent": "~0.15"
   },


### PR DESCRIPTION
Changed reference from `apostle.js` to `index.js` in `package.json`.  It was breaking when being required in a node.js project using 
`var apostle = require ('apostle.io');`
