### PR TITLE
updated request handler to be an error first callback

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,7 @@ function send(payload, promise) {
 		.send(payload)
 		.set('Authorization', 'Bearer ' + apostle.domainKey)
 		.set('Apostle-Client', 'JavaScript/v0.1.1')
-		.end(function(res){
+		.end(function(err, res){
 			if(res.ok){
 				promise.fulfill()
 			}else{


### PR DESCRIPTION
the superagent package expects an error first callback. See example on npm page: [npm page](https://www.npmjs.com/package/superagent).